### PR TITLE
Changing keyboard mapping so it will not conflic with pep-8 checker.

### DIFF
--- a/main.js
+++ b/main.js
@@ -53,7 +53,8 @@ define(function (require, exports, module) {
     // Then create a menu item bound to the command
     // The label of the menu item is the name we gave the command (see above)
     var menu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);
-    menu.addMenuItem(MY_COMMAND_ID, "Ctrl-Shift-P");
+    // we use J here because P conficts with pep8 checker.
+    menu.addMenuItem(MY_COMMAND_ID, "Ctrl-Shift-J");
 
     exports.prettyJson = prettyJson;
 });


### PR DESCRIPTION
Cannot assign Shift-Cmd-P to PrettyJson.MakePrettyJson. It is already assigned to python-pep8.run /command/KeyBindingManager.js:463

I assume that Shift-Ctrl-J should be ok for this. Initially, i was thinking of B as it comes from beautiful but that is used by a Bower extension. J comes from JSON and i couldn't find any conflict.
