### PR TITLE
Changed extension to use editor tab/space settings for JSON.stringify()

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,9 +11,9 @@ define(function (require, exports, module) {
         EditorManager  = brackets.getModule("editor/EditorManager"),
         DocumentManager = brackets.getModule("document/DocumentManager"),
         Menus          = brackets.getModule("command/Menus"),
-        CodeInspection = brackets.getModule("language/CodeInspection");
+        CodeInspection = brackets.getModule("language/CodeInspection"),
+        PreferencesManager = brackets.getModule("preferences/PreferencesManager");
 
-    
     // Function to run when the menu item is clicked
     function prettyJson() {
         var editor = EditorManager.getCurrentFullEditor();
@@ -52,7 +52,8 @@ define(function (require, exports, module) {
                 }
                 return;
             }
-            var formattedText = JSON.stringify(obj, null, "\t");
+            // Format JSON based on the current editor settings
+            var formattedText = JSON.stringify(obj, null, (PreferencesManager.get("useTabChar")?"\t":PreferencesManager.get("spaceUnits"));
             
             var doc = DocumentManager.getCurrentDocument();
             
@@ -100,11 +101,11 @@ define(function (require, exports, module) {
     
     // First, register a command - a UI-less object associating an id to a handler
     var MY_COMMAND_ID = "PrettyJson.MakePrettyJson";   // package-style naming to avoid collisions
-    CommandManager.register("PrettyJson", MY_COMMAND_ID, prettyJson);
+    CommandManager.register("JSON Formatter", MY_COMMAND_ID, prettyJson);
 
     // Then create a menu item bound to the command
     // The label of the menu item is the name we gave the command (see above)
-    var menu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);
+    var menu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
     // we use J here because P conficts with pep8 checker.
     menu.addMenuItem(MY_COMMAND_ID, "Ctrl-Shift-J");
 


### PR DESCRIPTION
Hi Stephen

I have updated the extension to use the editors settings. This way if I have tabs setup and a team mate has space, we get the desired results when we run this to clean up JSON.

I also moved it from the file menu to the edit menu. It is not opening or saving files and all other extensions I have that reformat a file currently reside in the edit menu. Therefor it made more sense to me to move it. I also changed the string that was placed on the menu as it has no spaces or formatting. Feel free to change the wording.

Simon
